### PR TITLE
Removed .ToLower() to fix case-sensitivity on texture paths.

### DIFF
--- a/Plugins/Wavefront/WavefrontImportPlugin.cs
+++ b/Plugins/Wavefront/WavefrontImportPlugin.cs
@@ -100,27 +100,28 @@
         /// <param name="mtlPath">MTL texture path</param>
         /// <param name="modelFolder">Model folder path</param>
         /// <returns>Absolute texture file path</returns>
-        private static string? GetAbsoluteTexturePath(string mtlPath, string modelFolder)
-        {
-            try
-            {
-                if (File.Exists(mtlPath))
-                {
-                    return mtlPath.ToLower();
-                }
-            }
-            catch (Exception ex)
-            {
-                ex.ToString();
-            }
+	private static string? GetAbsoluteTexturePath(string mtlPath, string modelFolder)
+	{
+	    if (string.IsNullOrWhiteSpace(mtlPath)) 
+		return null;
 
-            if (!string.IsNullOrWhiteSpace(mtlPath))
-            {
-                return Path.Combine(modelFolder, mtlPath).ToLower();
-            }
+	    try
+	    {
+		if (Path.IsPathRooted(mtlPath) && File.Exists(mtlPath))
+		{
+		    return mtlPath;
+		}
 
-            return null;
-        }
+		string combinedPath = Path.Combine(modelFolder, mtlPath);
+		return Path.GetFullPath(combinedPath);
+	    }
+	    catch (Exception ex)
+	    {
+		// Log the exception if you have a logger, otherwise:
+		Console.WriteLine($"Error resolving path: {ex.Message}");
+		return null;
+	    }
+	}
 
         /// <summary>
         /// parse color

--- a/Plugins/Wavefront/WavefrontImportPlugin.cs
+++ b/Plugins/Wavefront/WavefrontImportPlugin.cs
@@ -100,28 +100,27 @@
         /// <param name="mtlPath">MTL texture path</param>
         /// <param name="modelFolder">Model folder path</param>
         /// <returns>Absolute texture file path</returns>
-	private static string? GetAbsoluteTexturePath(string mtlPath, string modelFolder)
-	{
-	    if (string.IsNullOrWhiteSpace(mtlPath)) 
-		return null;
+        private static string? GetAbsoluteTexturePath(string mtlPath, string modelFolder)
+        {
+            if (string.IsNullOrWhiteSpace(mtlPath)) 
+                return null;
 
-	    try
-	    {
-		if (Path.IsPathRooted(mtlPath) && File.Exists(mtlPath))
-		{
-		    return mtlPath;
-		}
+            try
+            {
+                if (Path.IsPathRooted(mtlPath) && File.Exists(mtlPath))
+                {
+                    return mtlPath;
+                }
 
-		string combinedPath = Path.Combine(modelFolder, mtlPath);
-		return Path.GetFullPath(combinedPath);
-	    }
-	    catch (Exception ex)
-	    {
-		// Log the exception if you have a logger, otherwise:
-		Console.WriteLine($"Error resolving path: {ex.Message}");
-		return null;
-	    }
-	}
+                string combinedPath = Path.Combine(modelFolder, mtlPath);
+                return Path.GetFullPath(combinedPath);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error resolving path: {ex.Message}");
+                return null;
+            }
+        }
 
         /// <summary>
         /// parse color


### PR DESCRIPTION
This was breaking paths unless they were 100% lowercase to start with.

I tried to convert a model that used a texture located at
path/to/TEXTURE/texture.tga

but it wasn't working properly because the importer turned it into
path/to/texture/texture.tga

And therefore the exporter plugin couldn't find the texture anymore when creating the .NYA