### PR TITLE
Updated to dotnet10, upgraded ImageSharp

### DIFF
--- a/ModelConverter/ModelConverter.csproj
+++ b/ModelConverter/ModelConverter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<OutputPath>..\BuildDrop</OutputPath>

--- a/Plugins/Nya/Nya.csproj
+++ b/Plugins/Nya/Nya.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<OutputPath>..\..\BuildDrop\Plugins\Nya</OutputPath>
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+	  <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Plugins/Tmf/TankModelFormatExportPlugin.cs
+++ b/Plugins/Tmf/TankModelFormatExportPlugin.cs
@@ -169,7 +169,8 @@
                     Marshal.StructureToPtr(data, ptr, true);
                     Marshal.Copy(ptr, array, 0, length);
                     Marshal.FreeHGlobal(ptr);
-                    bytes.AddRange(array.Reverse());
+                    Array.Reverse(array);
+                    bytes.AddRange(array);
                 }
             }
 

--- a/Plugins/Tmf/Tmf.csproj
+++ b/Plugins/Tmf/Tmf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<OutputPath>..\..\BuildDrop\Plugins\Tmf</OutputPath>

--- a/Plugins/Wavefront/Wavefront.csproj
+++ b/Plugins/Wavefront/Wavefront.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<OutputPath>..\..\BuildDrop\Plugins\Wavefront</OutputPath>


### PR DESCRIPTION
I updated the tool to build on dotnet10.0 since 6.0 is deprecated on macOS. Also upgraded ImageSharp because version 3.1.7 had a vulnerability:

```
/Users/jfsantos/src/ModelConverter-linux/Plugins/Nya/Nya.csproj : warning NU1902: Package 'SixLabors.ImageSharp' 3.1.7 has a known moderate severity
vulnerability, https://github.com/advisories/GHSA-rxmq-m78w-7wmc
```